### PR TITLE
Fixed the issue due to collision of title in translation for header.

### DIFF
--- a/src/assets/locales/en/form.json
+++ b/src/assets/locales/en/form.json
@@ -28,7 +28,7 @@
     }
   ],
   "showingResults": "Showing {{start}} to {{end}} of {{total}} results ",
-  "quickLinks": "Quick links",
+  "formQuickLinks": "Quick links",
   "quickLink1": "Form / information",
   "quickLink2": "Publications / reports",
   "quickLink3": "Acts / regulations",

--- a/src/assets/locales/ne/form.json
+++ b/src/assets/locales/ne/form.json
@@ -28,7 +28,7 @@
     }
   ],
   "showingResults": "{{start}} देखि {{end}} सम्म {{total}} परिणामहरू देखाउँदै",
-  "quickLinks": "द्रुत लिंकहरू",
+  "formQuickLinks": "द्रुत लिंकहरू",
   "quickLink1": "फारम / जानकारी",
   "quickLink2": "प्रकाशनहरू / रिपोर्टहरू",
   "quickLink3": "ऐन / नियमहरू",

--- a/src/pages/FormPage.jsx
+++ b/src/pages/FormPage.jsx
@@ -66,7 +66,7 @@ const FormsInformation = () => {
         </div>
         <div className="w-full md:w-1/3 md:ml-4">
           <h2 className="text-2xl font-bold text-blue-800 mb-4">
-            {t("quickLinks")}
+            {t("formQuickLinks")}
           </h2>
           <ul>
             {quickLinks.map((link, index) => (


### PR DESCRIPTION
There was an issue in the navigation links of the footer section which occurred due to the collision of the name in both the translation files. The issue was resolved by changing name in one of the translation.